### PR TITLE
GitHub WorkflowでビルドしたDockerイメージがプッ処できていなかった問題を修正

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -24,6 +24,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -9,6 +9,11 @@ on:
 jobs:
   docker-build:
     runs-on: ubuntu-22.04
+
+    permissions:
+      packages: write
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -4,7 +4,6 @@ run-name: Docker Build:${{ github.ref_name }}(${{ github.event.head_commit.messa
 
 on:
   push:
-  pull_request:
 
 jobs:
   docker-build:


### PR DESCRIPTION
- permissionにpackages: writeを追加
- docker-login-actionでlogoutしないように修正
- PRでbuildを行わないように変更