### PR TITLE
GitHub ActionsのAdd Tagがうまく行かなかった問題を修正 (#11)

### DIFF
--- a/.github/workflows/add_tag.yaml
+++ b/.github/workflows/add_tag.yaml
@@ -8,8 +8,11 @@ on:
      - main
 
 jobs:
-  version-chack:
+  add-tag:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@ limitations under the License. -->
 
 <package format="3">
   <name>traps_tools_ros</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>TRAPSで使用するROS2のツール類</description>
   <maintainer email="traps.robocup@gmail.com">TRAPS</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
- job名をadd-tagに修正
- ermissionsにcontents: writeを追加