### PR TITLE
Dockerイメージを更新

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /root/ros2_ws
 USER root
 
 # リポジトリとws_entry_point.shのコピー
-COPY . ./src/${PACKAGE_NAME}/.
+COPY . "./src/${PACKAGE_NAME}/."
 COPY ./.docker/ws_entrypoint.sh /.
 RUN chmod +x /ws_entrypoint.sh
 
@@ -36,7 +36,7 @@ RUN chmod +x /ws_entrypoint.sh
 RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.git/config
 
 # パッケージのインストール
-RUN apt-get update && apt-get install -y $(echo ${REQUIRED_APTS}) lsb-release wget software-properties-common gnupg
+RUN apt-get update && xargs -a apt-get install -y lsb-release wget software-properties-common gnupg
 RUN rosdep install -iy --from-paths src
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# 引数設定
+# イメージ引数設定
 ARG BASE_IMAGE=humble-ros-base
-ARG PACKAGE_NAME
 
 # プラットフォームとベースのイメージを設定
 FROM --platform=$BUILDPLATFORM ros:${BASE_IMAGE}
+
+# ビルド引数設定
+ARG PACKAGE_NAME
 
 # 設定されたワークスペースに移動
 WORKDIR /root/ros2_ws
@@ -34,12 +36,15 @@ RUN chmod +x /ws_entrypoint.sh
 RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.git/config
 
 # パッケージのインストール
-RUN apt-get update && apt-get install -y $(echo ${REQUIRED_APTS})
+RUN apt-get update && apt-get install -y $(echo ${REQUIRED_APTS}) lsb-release wget software-properties-common gnupg
 RUN rosdep install -iy --from-paths src
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# clang-18のインストール
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
+
 # ビルド
-RUN . /opt/ros/humble/setup.sh && colcon build
+RUN . /opt/ros/humble/setup.sh && colcon build --cmake-args -D CMAKE_C_COMPILER=clang-18 -D CMAKE_CXX_COMPILER=clang++-18
 RUN rm -rf ./log
 
 # .bashrcへの書き込み

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -36,7 +36,7 @@ RUN chmod +x /ws_entrypoint.sh
 RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.git/config
 
 # パッケージのインストール
-RUN apt-get update && xargs -a apt-get install -y lsb-release wget software-properties-common gnupg
+RUN apt-get update && xargs -a ./config/apt/requirements.txt apt-get install -y lsb-release wget software-properties-common gnupg
 RUN rosdep install -iy --from-paths src
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -36,7 +36,7 @@ RUN chmod +x /ws_entrypoint.sh
 RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.git/config
 
 # パッケージのインストール
-RUN apt-get update && xargs -a ./config/apt/requirements.txt apt-get install -y lsb-release wget software-properties-common gnupg
+RUN apt-get update && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
 RUN rosdep install -iy --from-paths src
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -53,5 +53,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            PACKAGE_NAME="${{ steps.repository.outputs.name }}"
-            REQUIRED_APTS=""
+            PACKAGE_NAME=${{ steps.repository.outputs.name }}
+          no-cache: true

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -55,3 +55,6 @@ jobs:
           build-args: |
             PACKAGE_NAME=${{ steps.repository.outputs.name }}
           no-cache: true
+          platforms: |
+            linux/amd64
+            linux/arm64/v8

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@ limitations under the License. -->
 
 <package format="3">
   <name>traps_tools_ros</name>
-  <version>0.0.6</version>
+  <version>0.0.7</version>
   <description>TRAPSで使用するROS2のツール類</description>
   <maintainer email="traps.robocup@gmail.com">TRAPS</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
- GitHub Actionsのbuild-argsからダブルクォーテーションを削除して、DockerFileに追加
- 必須aptをconfig/apt/requirements.txtに記載
- GitHub ActionsでDocker buildをするときにcacheを使わないように変更
- GitHub ActionsでDocker buildをするときにplatformsを指定していなかった問題を修正