### PR TITLE
Dockerイメージを更新

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -41,8 +41,6 @@ RUN rosdep update && rosdep install -iy --from-paths src
 RUN rm ./llvm.sh && apt-get remove -y lsb-release wget software-properties-common gnupg
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# clang-18のインストール
-
 # ビルド
 RUN . /opt/ros/humble/setup.sh && colcon build --cmake-args -D CMAKE_C_COMPILER=clang-18 -D CMAKE_CXX_COMPILER=clang++-18
 RUN rm -rf ./log

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -16,7 +16,7 @@
 ARG BASE_IMAGE=humble-ros-base
 
 # プラットフォームとベースのイメージを設定
-FROM --platform=$BUILDPLATFORM ros:${BASE_IMAGE}
+FROM ros:${BASE_IMAGE}
 
 # 設定されたワークスペースに移動
 WORKDIR /root/ros2_ws

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -37,7 +37,7 @@ RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.gi
 # パッケージのインストール
 RUN apt-get update && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
-RUN rosdep install -iy --from-paths src
+RUN rosdep update && rosdep install -iy --from-paths src
 RUN rm ./llvm.sh && apt-get remove lsb-release wget software-properties-common gnupg
 RUN 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -35,12 +35,11 @@ RUN chmod +x /ws_entrypoint.sh
 RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.git/config
 
 # パッケージのインストール
-RUN apt-get update && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
+RUN apt-get update && apt-get upgrade -y && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
 RUN rosdep update && rosdep install -iy --from-paths src
 RUN rm ./llvm.sh && apt-get remove lsb-release wget software-properties-common gnupg
-RUN 
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clang-18のインストール
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get upgrade -y && xargs -a "./src/${PACKAGE_NAME}/conf
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
 RUN rosdep update && rosdep install -iy --from-paths src
 RUN rm ./llvm.sh && apt-get remove -y lsb-release wget software-properties-common gnupg
-RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clang-18のインストール
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -18,9 +18,6 @@ ARG BASE_IMAGE=humble-ros-base
 # プラットフォームとベースのイメージを設定
 FROM --platform=$BUILDPLATFORM ros:${BASE_IMAGE}
 
-# ビルド引数設定
-ARG PACKAGE_NAME
-
 # 設定されたワークスペースに移動
 WORKDIR /root/ros2_ws
 
@@ -28,7 +25,9 @@ WORKDIR /root/ros2_ws
 USER root
 
 # リポジトリとws_entry_point.shのコピー
-COPY . "./src/${PACKAGE_NAME}/."
+COPY . "./src/package/."
+ARG PACKAGE_NAME=$(xmllint --xpath "string(/package/name)" "./src/package/package.xml")
+RUN mv "./src/package" "./src/${PACKAGE_NAME}"
 COPY ./.docker/ws_entrypoint.sh /.
 RUN chmod +x /ws_entrypoint.sh
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -36,7 +36,7 @@ RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.gi
 
 # パッケージのインストール
 RUN apt-get update && apt-get upgrade -y && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
-RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 18
 RUN rosdep update && rosdep install -iy --from-paths src
 RUN rm ./llvm.sh && apt-get remove -y lsb-release wget software-properties-common gnupg
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -36,11 +36,13 @@ RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.gi
 
 # パッケージのインストール
 RUN apt-get update && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
 RUN rosdep install -iy --from-paths src
+RUN rm ./llvm.sh && apt-get remove lsb-release wget software-properties-common gnupg
+RUN 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clang-18のインストール
-RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
 
 # ビルド
 RUN . /opt/ros/humble/setup.sh && colcon build --cmake-args -D CMAKE_C_COMPILER=clang-18 -D CMAKE_CXX_COMPILER=clang++-18

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -38,7 +38,7 @@ RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.gi
 RUN apt-get update && apt-get upgrade -y && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
 RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
 RUN rosdep update && rosdep install -iy --from-paths src
-RUN rm ./llvm.sh && apt-get remove lsb-release wget software-properties-common gnupg
+RUN rm ./llvm.sh && apt-get remove -y lsb-release wget software-properties-common gnupg
 RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clang-18のインストール

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -45,6 +45,7 @@ jobs:
 
 
       - name: Set up Docker Buildx
+        id: builder
         uses: docker/setup-buildx-action@v3
         with:
           platforms: ${{ env.PLATFORMS }}
@@ -61,3 +62,4 @@ jobs:
             PACKAGE_NAME=${{ steps.repository.outputs.name }}
           no-cache: true
           platforms: ${{ env.PLATFORMS }}
+          builder: ${{ steps.builder.outputs.name }}

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -13,6 +13,12 @@ jobs:
       packages: write
       contents: read
 
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64/v8
+
     steps:
       - name: Resist repository name
         id: repository
@@ -41,9 +47,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: |
-            linux/amd64
-            linux/arm64/v8
+          platforms: ${{ matrix.platform }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -56,6 +60,4 @@ jobs:
           build-args: |
             PACKAGE_NAME=${{ steps.repository.outputs.name }}
           no-cache: true
-          platforms: |
-            linux/amd64
-            linux/arm64/v8
+          platforms: ${{ matrix.platform }}

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -41,7 +41,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          image: ubuntu:22.04
           platforms: ${{ env.PLATFORMS }}
 
 

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -13,9 +13,8 @@ jobs:
       packages: write
       contents: read
 
-    strategy:
-      env:
-        PLATFORMS: linux/amd64, linux/arm64/v8
+    env:
+      PLATFORMS: linux/amd64, linux/arm64/v8
 
     steps:
       - name: Resist repository name

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
+          image: ubuntu:22.04
           platforms: ${{ env.PLATFORMS }}
 
 

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -14,10 +14,8 @@ jobs:
       contents: read
 
     strategy:
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64/v8
+      env:
+        PLATFORMS: linux/amd64, linux/arm64/v8
 
     steps:
       - name: Resist repository name
@@ -44,13 +42,13 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ env.PLATFORMS }}
 
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ env.PLATFORMS }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -63,4 +61,4 @@ jobs:
           build-args: |
             PACKAGE_NAME=${{ steps.repository.outputs.name }}
           no-cache: true
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -43,6 +43,9 @@ jobs:
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.platform }}
+
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
- GitHub ActionsでDocker Buildをするときのplatformをenvにまとめた
- GitHub ActionsのDocker BuildのQEMUのplatformを指定
- DockerのClang18のインストールに使ったファイルやパッケージを消すように変更
- DockerFileにrosdep updateを追加
- DockerFileにapt-get upgradeと不要なファイルのapt-get removeを追加
- DockerFileから不要なsudoを削除
- GitHub ActionsのDocker Buildでbuilderを指定
- DockerFileから--platformを削除(arm64/v8でexec format errorが出ていた問題の修正)