### PR TITLE
Dockerイメージを更新 (#39) 

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -16,10 +16,7 @@
 ARG BASE_IMAGE=humble-ros-base
 
 # プラットフォームとベースのイメージを設定
-FROM --platform=$BUILDPLATFORM ros:${BASE_IMAGE}
-
-# ビルド引数設定
-ARG PACKAGE_NAME
+FROM ros:${BASE_IMAGE}
 
 # 設定されたワークスペースに移動
 WORKDIR /root/ros2_ws
@@ -28,7 +25,9 @@ WORKDIR /root/ros2_ws
 USER root
 
 # リポジトリとws_entry_point.shのコピー
-COPY . "./src/${PACKAGE_NAME}/."
+COPY . "./src/package/."
+ARG PACKAGE_NAME=$(xmllint --xpath "string(/package/name)" "./src/package/package.xml")
+RUN mv "./src/package" "./src/${PACKAGE_NAME}"
 COPY ./.docker/ws_entrypoint.sh /.
 RUN chmod +x /ws_entrypoint.sh
 
@@ -36,12 +35,11 @@ RUN chmod +x /ws_entrypoint.sh
 RUN sed -i '/\[http "https:\/\/github\.com\/"\]/,+1 d' ./src/${PACKAGE_NAME}/.git/config
 
 # パッケージのインストール
-RUN apt-get update && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
-RUN rosdep install -iy --from-paths src
+RUN apt-get update && apt-get upgrade -y && xargs -a "./src/${PACKAGE_NAME}/config/apt/requirements.txt" apt-get install -y lsb-release wget software-properties-common gnupg
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 18
+RUN rosdep update && rosdep install -iy --from-paths src
+RUN rm ./llvm.sh && apt-get remove -y lsb-release wget software-properties-common gnupg
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# clang-18のインストール
-RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 18
 
 # ビルド
 RUN . /opt/ros/humble/setup.sh && colcon build --cmake-args -D CMAKE_C_COMPILER=clang-18 -D CMAKE_CXX_COMPILER=clang++-18

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -13,6 +13,9 @@ jobs:
       packages: write
       contents: read
 
+    env:
+      PLATFORMS: linux/amd64, linux/arm64/v8
+
     steps:
       - name: Resist repository name
         id: repository
@@ -37,13 +40,15 @@ jobs:
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ env.PLATFORMS }}
+
 
       - name: Set up Docker Buildx
+        id: builder
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: |
-            linux/amd64
-            linux/arm64/v8
+          platforms: ${{ env.PLATFORMS }}
 
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -56,6 +61,5 @@ jobs:
           build-args: |
             PACKAGE_NAME=${{ steps.repository.outputs.name }}
           no-cache: true
-          platforms: |
-            linux/amd64
-            linux/arm64/v8
+          platforms: ${{ env.PLATFORMS }}
+          builder: ${{ steps.builder.outputs.name }}

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@ limitations under the License. -->
 
 <package format="3">
   <name>traps_tools_ros</name>
-  <version>0.0.8</version>
+  <version>0.0.9</version>
   <description>TRAPSで使用するROS2のツール類</description>
   <maintainer email="traps.robocup@gmail.com">TRAPS</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
- GitHub ActionsでDocker Buildをするときのplatformをenvにまとめた
- GitHub ActionsのDocker BuildのQEMUのplatformを指定
- DockerのClang18のインストールに使ったファイルやパッケージを消すように変更
- DockerFileにrosdep updateを追加
- DockerFileにapt-get upgradeと不要なファイルのapt-get removeを追加
- DockerFileから不要なsudoを削除
- GitHub ActionsのDocker Buildでbuilderを指定
- DockerFileから--platformを削除(arm64/v8でexec format errorが出ていた問題の修正)